### PR TITLE
Disable cert check with a flag

### DIFF
--- a/certbot/upload.py
+++ b/certbot/upload.py
@@ -13,6 +13,11 @@ if os.environ.get('TRUST_LE_STAGING') == 'yes':
         cafile=Path(__file__).parent.resolve().joinpath('fakelerootx1.pem'),
     )
 
+if os.environ.get('DANGER_DISABLE_CERT_CHECK') == 'yes':
+    print('!!! Disabling TLS certification verification.')
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.VerifyMode.CERT_NONE
+
 # debuglevel=10
 log_handler = urllib.request.HTTPSHandler(context=ssl_context)
 opener = urllib.request.build_opener(log_handler)


### PR DESCRIPTION
When the coordinator's TLS cert has expired, it's a pain in the neck to fix it and manually upload a new one. Let's add a flag I can use to bypass certification validation manually in that case so that I can patch things up.